### PR TITLE
Test too long comment

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -390,6 +390,10 @@ def test_custom_comment():
     # Lazy method to determine if the comment is in the image generated
     assert bytes(unique_comment, "utf-8") in data
 
+    too_long_comment = " " * 65532
+    with pytest.raises(ValueError):
+        test_card.save(output_stream, "JPEG2000", comment=too_long_comment)
+
 
 @skip_unless_feature_version("jpg_2000", "2.4.0")
 def test_plt_marker():

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -12,6 +12,7 @@ from .helper import (
     assert_image_similar,
     assert_image_similar_tofile,
     skip_unless_feature,
+    skip_unless_feature_version,
 )
 
 EXTRA_DIR = "Tests/images/jpeg2000"
@@ -384,34 +385,31 @@ def test_custom_comment():
     assert bytes(unique_comment, "utf-8") in data
 
 
+@skip_unless_feature_version("jpg_2000", "2.4.0")
 def test_plt_marker():
     # Search the start of the codesteam for the PLT box (id 0xFF58)
-    opj_version = re.search(r"(\d+\.\d+)\.\d+$", features.version_codec("jpg_2000"))
-    assert opj_version is not None
+    out = BytesIO()
+    test_card.save(out, "JPEG2000", no_jp2=True, add_plt=True)
+    out.seek(0)
+    while True:
+        box_bytes = out.read(2)
+        if len(box_bytes) == 0:
+            # End of steam encountered and no PLT or SOD
+            break
+        jp2_boxid = struct.unpack(">H", box_bytes)[0]
 
-    if float(opj_version[1]) >= 2.4:
-        out = BytesIO()
-        test_card.save(out, "JPEG2000", no_jp2=True, add_plt=True)
-        out.seek(0)
-        while True:
-            box_bytes = out.read(2)
-            if len(box_bytes) == 0:
-                # End of steam encountered and no PLT or SOD
-                break
-            jp2_boxid = struct.unpack(">H", box_bytes)[0]
+        if jp2_boxid == 0xFF4F:
+            # No length specifier for main header
+            continue
+        elif jp2_boxid == 0xFF58:
+            # This is the PLT box we're looking for
+            return
+        elif jp2_boxid == 0xFF93:
+            break
+            # SOD box encountered and no PLT, so it wasn't found
 
-            if jp2_boxid == 0xFF4F:
-                # No length specifier for main header
-                continue
-            elif jp2_boxid == 0xFF58:
-                # This is the PLT box we're looking for
-                return
-            elif jp2_boxid == 0xFF93:
-                break
-                # SOD box encountered and no PLT, so it wasn't found
+        jp2_boxlength = struct.unpack(">H", out.read(2))[0]
+        out.seek(jp2_boxlength - 2, os.SEEK_CUR)
 
-            jp2_boxlength = struct.unpack(">H", out.read(2))[0]
-            out.seek(jp2_boxlength - 2, os.SEEK_CUR)
-
-        # The PLT box wasn't found
-        raise ValueError
+    # The PLT box wasn't found
+    raise ValueError

--- a/src/encode.c
+++ b/src/encode.c
@@ -1214,7 +1214,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     char mct = 0;
     int sgnd = 0;
     Py_ssize_t fd = -1;
-    char * comment = NULL;
+    char *comment = NULL;
     int add_plt = 0;
 
     if (!PyArg_ParseTuple(
@@ -1326,7 +1326,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
                 PyExc_ValueError,
                 "JPEG 2000 comment is too long");
             Py_DECREF(encoder);
-            return NULL;            
+            return NULL;
         }
 
         context->comment = strdup(comment);
@@ -1338,8 +1338,6 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
             Py_DECREF(encoder);
             return NULL;
         }
-    } else {
-        context->comment = NULL;
     }
 
     if (quality_layers && PySequence_Check(quality_layers)) {

--- a/src/libImaging/Jpeg2K.h
+++ b/src/libImaging/Jpeg2K.h
@@ -98,7 +98,7 @@ typedef struct {
     const char *error_msg;
 
     /* Custom comment */
-    char * comment;
+    char *comment;
 
     /* Include PLT marker segment */
     int add_plt;


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6903

- The Pillow test suite has its [own function for checking dependency versions](https://github.com/python-pillow/Pillow/blob/f82546fa2e701037b4efc2846ca5e93a5ee922a6/Tests/helper.py#L164-L171). So let's make use of that
- Use Pillow's `_binary` instead of `struct`, as it is simpler.
- Test the error that is raised when a comment is too long
- Removed setting `context->comment = NULL;` when there is no comment, as it seems unnecessary.