### PR TITLE
Read comment in test

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -373,15 +373,15 @@ def test_comment():
 
 
 def test_save_comment():
-    comment = "Created by Pillow"
-    out = BytesIO()
-    test_card.save(out, "JPEG2000", comment=comment)
-    out.seek(0)
+    for comment in ("Created by Pillow", b"Created by Pillow"):
+        out = BytesIO()
+        test_card.save(out, "JPEG2000", comment=comment)
+        out.seek(0)
 
-    with Image.open(out) as im:
-        assert im.info["comment"] == b"Created by Pillow"
+        with Image.open(out) as im:
+            assert im.info["comment"] == b"Created by Pillow"
 
-    too_long_comment = " " * 65532
+    too_long_comment = " " * 65531
     with pytest.raises(ValueError):
         test_card.save(out, "JPEG2000", comment=too_long_comment)
 

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -372,6 +372,20 @@ def test_comment():
             pass
 
 
+def test_save_comment():
+    comment = "Created by Pillow"
+    out = BytesIO()
+    test_card.save(out, "JPEG2000", comment=comment)
+    out.seek(0)
+
+    with Image.open(out) as im:
+        assert im.info["comment"] == b"Created by Pillow"
+
+    too_long_comment = " " * 65532
+    with pytest.raises(ValueError):
+        test_card.save(out, "JPEG2000", comment=too_long_comment)
+
+
 @pytest.mark.parametrize(
     "test_file",
     [
@@ -389,20 +403,6 @@ def test_crashes(test_file):
                 im.load()
             except OSError:
                 pass
-
-
-def test_custom_comment():
-    output_stream = BytesIO()
-    unique_comment = "This is a unique comment, which should be found below"
-    test_card.save(output_stream, "JPEG2000", comment=unique_comment)
-    output_stream.seek(0)
-    data = output_stream.read()
-    # Lazy method to determine if the comment is in the image generated
-    assert bytes(unique_comment, "utf-8") in data
-
-    too_long_comment = " " * 65532
-    with pytest.raises(ValueError):
-        test_card.save(output_stream, "JPEG2000", comment=too_long_comment)
 
 
 @skip_unless_feature_version("jpg_2000", "2.4.0")

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -351,10 +351,12 @@ def _save(im, fp, filename):
     cinema_mode = info.get("cinema_mode", "no")
     mct = info.get("mct", 0)
     signed = info.get("signed", False)
-    fd = -1
     comment = info.get("comment")
+    if isinstance(comment, str):
+        comment = comment.encode()
     add_plt = info.get("add_plt", False)
 
+    fd = -1
     if hasattr(fp, "fileno"):
         try:
             fd = fp.fileno()


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6903

Now that https://github.com/python-pillow/Pillow/pull/6909 has been merged, the JPEG2000 comment can be read properly after saving.

I have also added a commit to allow bytestrings to be saved as comments.